### PR TITLE
add links to blog posts for Documents API and GraphQL API

### DIFF
--- a/modules/developers-guide/pages/document-using.adoc
+++ b/modules/developers-guide/pages/document-using.adoc
@@ -271,6 +271,8 @@ include::example$bash/docapi_curl_drop_ns.sh[]
 All data written with the Document API is stored as JSON documents stored in
 collections.
 
+include::partial$DocAPIBlogPost.adoc[]
+
 ==== Add document specifying a collection name
 
 First, let's add a document to a specified collection.

--- a/modules/developers-guide/pages/graphql-using.adoc
+++ b/modules/developers-guide/pages/graphql-using.adoc
@@ -3,6 +3,7 @@
 Stargate is a data gateway deployed between client applications and a database.
 The GraphQL API plugin that exposes CRUD access to data stored in Cassandra tables.
 
+include::partial$GQLAPIBlogPost.adoc[]
 
 // tag::prereqsList[]
 include::partial$prereqs.adoc[]

--- a/modules/developers-guide/partials/DocAPIBlogPost.adoc
+++ b/modules/developers-guide/partials/DocAPIBlogPost.adoc
@@ -1,0 +1,5 @@
+[TIP]
+====
+For more information about the database design of the Document API, see
+https://stargate.io/2020/10/19/the-stargate-cassandra-documents-api.html[the blog post on the Documents API].
+====

--- a/modules/developers-guide/partials/GQLAPIBlogPost.adoc
+++ b/modules/developers-guide/partials/GQLAPIBlogPost.adoc
@@ -1,0 +1,5 @@
+[TIP]
+====
+For more information about the GraphQL API, see
+https://stargate.io/2020/10/05/hello-graphql.html[the blog post on the GraphQL API].
+====

--- a/modules/quickstart/pages/quick_start-document.adoc
+++ b/modules/quickstart/pages/quick_start-document.adoc
@@ -65,6 +65,8 @@ include::developers-guide:page$document-using.adoc[tag=DeleteNS]
 // write document data
 include::developers-guide:page$document-using.adoc[tag=WriteBasicData]
 
+include::developers-guide:partial$DocAPIBlogPost.adoc[]
+
 // read document data
 include::developers-guide:page$document-using.adoc[tag=ReadBasicData]
 

--- a/modules/quickstart/pages/quick_start-graphql.adoc
+++ b/modules/quickstart/pages/quick_start-graphql.adoc
@@ -6,6 +6,8 @@ Stargate is a data gateway deployed between client applications and a database.
 In this QuickStart, you'll be up and running on your local machine with the
 GraphQL API plugin that exposes CRUD access to data stored in Cassandra tables.
 
+include::developers-guide:partial$GQLAPIBlogPost.adoc[]
+
 // tag::prereqsList[]
 include::developers-guide:partial$prereqs.adoc[]
 // end::prereqsList[]


### PR DESCRIPTION
Added link to Doc API in the Write Data section, to point to the database table design. Added link at top of page for GraphQL pages while I was doing the other work.