### PR TITLE
Replace quotes by double quotes to avoid 401

### DIFF
--- a/modules/developers-guide/examples/bash/docapi_curl_check_ns_exists.sh
+++ b/modules/developers-guide/examples/bash/docapi_curl_check_ns_exists.sh
@@ -1,3 +1,3 @@
 curl -L -X GET 'localhost:8082/v2/schemas/namespaces' \
--H 'X-Cassandra-Token: $AUTH_TOKEN' \
+-H "X-Cassandra-Token: $AUTH_TOKEN" \
 -H 'Content-Type: application/json'

--- a/modules/developers-guide/examples/bash/docapi_curl_create_ns.sh
+++ b/modules/developers-guide/examples/bash/docapi_curl_create_ns.sh
@@ -1,5 +1,5 @@
 curl -L -X POST 'localhost:8082/v2/schemas/namespaces' \
--H 'X-Cassandra-Token: $AUTH_TOKEN' \
+-H "X-Cassandra-Token: $AUTH_TOKEN" \
 -H 'Content-Type: application/json' \
 -d '{
     "name": "myworld",

--- a/modules/developers-guide/examples/bash/rest_curl_add_column.sh
+++ b/modules/developers-guide/examples/bash/rest_curl_add_column.sh
@@ -1,5 +1,5 @@
 curl -L -X POST 'localhost:8082/v2/schemas/keyspaces/users_keyspace/tables/users/columns' \
--H 'X-Cassandra-Token: $AUTH_TOKEN' \
+-H "X-Cassandra-Token: $AUTH_TOKEN" \
 -H  'accept: application/json' \
 -H 'Content-Type: application/json' \
 -d '{  

--- a/modules/developers-guide/examples/bash/rest_curl_change_column.sh
+++ b/modules/developers-guide/examples/bash/rest_curl_change_column.sh
@@ -1,6 +1,6 @@
 curl -L \
 -X PUT "http://localhost:8082/v2/schemas/keyspaces/users_keyspace/tables/users/columns/firstname" \
--H 'X-Cassandra-Token: $AUTH_TOKEN' \
+-H "X-Cassandra-Token: $AUTH_TOKEN" \
 -H 'Content-Type: application/json' \ 
  -d '{  
  "name": "first",  


### PR DESCRIPTION
Some `curl` commands are not using the `AUTH_TOKEN` variable because of simple quotes.