### PR TITLE
Make Auth API links consistent

### DIFF
--- a/modules/developers-guide/pages/api_ref/apiref.adoc
+++ b/modules/developers-guide/pages/api_ref/apiref.adoc
@@ -1,8 +1,8 @@
 = Stargate API reference
 
-Currently, the followin Data APIs exist for Stargate:
+Currently, the following Data APIs exist for Stargate:
 
-* xref:auth.adoc[Auth API]
+* xref:authnz.adoc[Auth API]
 * xref:api_ref/openapi_rest_ref.adoc[REST API]
 * xref:api_ref/openapi_document_ref.adoc[Document API]
 * https://cassandra.apache.org/doc/latest/cql/[CQL reference]


### PR DESCRIPTION
From the nav bar clicking on the "Auth API" link sends you to `https://stargate.io/docs/stargate/1.0/developers-guide/authnz.html` but navigating "API reference for Stargate" > "Auth API" sends you to `https://stargate.io/docs/stargate/1.0/developers-guide/auth.html`

If this is intended please let me know and I'll be happy to close