### PR TITLE
Fix postman links in using pages

### DIFF
--- a/modules/developers-guide/pages/document-using.adoc
+++ b/modules/developers-guide/pages/document-using.adoc
@@ -51,7 +51,7 @@ include::partial$use_auth_token_rest_document.adoc[]
 
 If you prefer, you can use Postman as a client interface for exploring the Document  API
 (https://www.postman.com/downloads/[download here]).
-See xref:tooling.adoc[Tooling Resources] for links to downloadable collections and environments.
+See xref:ROOT:tooling.adoc[Tooling Resources] for links to downloadable collections and environments.
 Instructions for configuring the environments for Stargate OSS and link:https://astra.datastax.com[Astra] are available.
 You can immediately import the documentation code examples and explore!
 // end::UsingPostman[]

--- a/modules/developers-guide/pages/document-using.adoc
+++ b/modules/developers-guide/pages/document-using.adoc
@@ -49,7 +49,7 @@ include::partial$use_auth_token_rest_document.adoc[]
 // tag::UsingPostman[]
 == Using Postman
 
-If you prefer, you can use Postman as a client interface for exploring the Document  API
+If you prefer, you can use Postman as a client interface for exploring the Document API
 (https://www.postman.com/downloads/[download here]).
 See xref:ROOT:tooling.adoc[Tooling Resources] for links to downloadable collections and environments.
 Instructions for configuring the environments for Stargate OSS and link:https://astra.datastax.com[Astra] are available.

--- a/modules/developers-guide/pages/document-using.adoc
+++ b/modules/developers-guide/pages/document-using.adoc
@@ -49,12 +49,11 @@ include::partial$use_auth_token_rest_document.adoc[]
 // tag::UsingPostman[]
 == Using Postman
 
-If you prefer, you can use Postman as a client interface for exploring the Document API
-(https://www.postman.com/downloads/[download here]). You will need to change the
-auth token to the header, in the collection global variables.
-We've provided a
-https://github.com/stargate/docs/blob/master/modules/developers-guide/examples/json/Stargate_Document_API_users.postman_collection.json[Stargate Document API Postman Collection]
-that you can import in Postman to play with the examples shown in this walkthrough.
+If you prefer, you can use Postman as a client interface for exploring the Document  API
+(https://www.postman.com/downloads/[download here]).
+See xref:tooling.adoc[Tooling Resources] for links to downloadable collections and environments.
+Instructions for configuring the environments for Stargate OSS and link:https://astra.datastax.com[Astra] are available.
+You can immediately import the documentation code examples and explore!
 // end::UsingPostman[]
 
 Now you're ready to use the Document API for CRUD operations.

--- a/modules/developers-guide/pages/graphql-using.adoc
+++ b/modules/developers-guide/pages/graphql-using.adoc
@@ -56,7 +56,7 @@ We'll start the playground with `/graphql-schema` to create some schema.
 
 If you prefer, you can use Postman as a client interface for exploring the GraphQL API
 (https://www.postman.com/downloads/[download here]).
-See xref:tooling.adoc[Tooling Resources] for links to downloadable collections and environments.
+See xref:ROOT:tooling.adoc[Tooling Resources] for links to downloadable collections and environments.
 Instructions for configuring the environments for Stargate OSS and link:https://astra.datastax.com[Astra] are available.
 You can immediately import the documentation code examples and explore!
 

--- a/modules/developers-guide/pages/graphql-using.adoc
+++ b/modules/developers-guide/pages/graphql-using.adoc
@@ -54,11 +54,11 @@ We'll start the playground with `/graphql-schema` to create some schema.
 // tag::UsingPostman[]
 == Using Postman
 
-If you prefer, you can use Postman as a client interface for exploring GraphQL APIs
+If you prefer, you can use Postman as a client interface for exploring the GraphQL API
 (https://www.postman.com/downloads/[download here]).
-We've provided a
-https://github.com/stargate/docs/blob/master/modules/developers-guide/examples/json/Stargate_GraphQL_API_users_keyspace.postman_collection.json[Stargate GraphQL API Postman Collection]
-that you can import in Postman to play with the examples shown in this walkthrough.
+See xref:tooling.adoc[Tooling Resources] for links to downloadable collections and environments.
+Instructions for configuring the environments for Stargate OSS and link:https://astra.datastax.com[Astra] are available.
+You can immediately import the documentation code examples and explore!
 
 Now you're ready to use the REST API for CRUD operations.
 // end::UsingPostman[]

--- a/modules/developers-guide/pages/rest-using.adoc
+++ b/modules/developers-guide/pages/rest-using.adoc
@@ -39,11 +39,11 @@ include::developers-guide:page$document-using.adoc[tag=UseAuthToken]
 // tag::UsingPostman[]
 == Using Postman
 
-If you prefer, you can use Postman as a client interface for exploring REST APIs
-(https://www.postman.com/downloads/[download here]).
-We've provided a
-https://github.com/stargate/docs/blob/master/modules/developers-guide/examples/json/Stargate_REST_v2_API_users_keyspace.postman_collection.json[Stargate REST API Postman Collection]
-that you can import in Postman to play with the examples shown in this walkthrough.
+If you prefer, you can use Postman as a client interface for exploring the REST API
+(https://www.postman.com/downloads/[download here]). 
+See xref:tooling.adoc[Tooling Resources] for links to downloadable collections and environments. 
+Instructions for configuring the environments for Stargate OSS and link:https://astra.datastax.com[Astra] are available.
+You can immediately import the documentation code examples and explore!
 
 Now you're ready to use the REST API for CRUD operations.
 // end::UsingPostman[]

--- a/modules/developers-guide/pages/rest-using.adoc
+++ b/modules/developers-guide/pages/rest-using.adoc
@@ -41,7 +41,7 @@ include::developers-guide:page$document-using.adoc[tag=UseAuthToken]
 
 If you prefer, you can use Postman as a client interface for exploring the REST API
 (https://www.postman.com/downloads/[download here]). 
-See xref:tooling.adoc[Tooling Resources] for links to downloadable collections and environments. 
+See xref:ROOT:tooling.adoc[Tooling Resources] for links to downloadable collections and environments. 
 Instructions for configuring the environments for Stargate OSS and link:https://astra.datastax.com[Astra] are available.
 You can immediately import the documentation code examples and explore!
 


### PR DESCRIPTION
needed to change the text in the Using APIs pages to point to Tooling Resources.