### PR TITLE
Update links to REST and Document API developer guides (fixes #150)

### DIFF
--- a/modules/ROOT/pages/api.adoc
+++ b/modules/ROOT/pages/api.adoc
@@ -6,8 +6,8 @@ Stargate  provides APIs to manage database resources.
 
 Stargate provides multiple APIs to connect to your database:
 
-* link:_attachments/docv2.html[Stargate Document API v2]: The Stargate Document API allows you to use schemaless storage of free-form JSON Documents in your database. Get examples of using the Document API in the xref:document-api.adoc[Developing your application/Document API] section.
-* link:_attachments/restv2.html[Stargate REST API v2]: The Stargate REST API allows you to perform standard CRUD operations on your data using a simple, cross-language interface. Get examples of using the REST API v2 in the xref:getting-started-with-datastax-astra.adoc[Developing your application/REST API] section.
+* link:_attachments/docv2.html[Stargate Document API v2]: The Stargate Document API allows you to use schemaless storage of free-form JSON Documents in your database. Get examples of using the Document API in the xref:developers-guide:document-using.adoc[Developing with Stargate/Document API] section.
+* link:_attachments/restv2.html[Stargate REST API v2]: The Stargate REST API allows you to perform standard CRUD operations on your data using a simple, cross-language interface. Get examples of using the REST API v2 in the xref:developers-guide:rest-using.adoc[Developing with Stargate/REST API] section.
 
 The xref:developers-guide:graphql.adoc[Stargate GraphQL API] allows you to easily interact with your data using GraphQL types, queries, and mutations. For every table in your keyspace, a series of GraphQL objects are generated, along with queries and mutations that allow you to search and modify the table data. Get examples of using the GraphQL API in the xref:developers-guide:graphql.adoc[Developing your application/GraphQL API] section.
 


### PR DESCRIPTION
### Summary

Updates the links to REST and Document API developer guides so they render correctly.  Also changes the link text slightly to match the page names. 