### PR TITLE
Fix the broken hyperlink to start Stargate with an existing Cassandra cluster

### DIFF
--- a/modules/developers-guide/pages/install/starctl.adoc
+++ b/modules/developers-guide/pages/install/starctl.adoc
@@ -13,7 +13,7 @@ starctl --cluster-name stargate \
   --simple-snitch
 ----
 
-CAUTION: When Stargate is launched on a host as shown above, it will connect only to Cassandra clusters accessible on the host's network. To run Stargate in a containerized environment, see the xref:existing_cstar.adoc[Installing Stargate with an existing Cassandra cluster] documentation.
+CAUTION: When Stargate is launched on a host as shown above, it will connect only to Cassandra clusters accessible on the host's network. To run Stargate in a containerized environment, see the xref:install_cass_40.adoc#_starting_stargate_with_existing_cassandra_cluster[Installing Stargate with an existing Cassandra cluster] documentation.
 
 == starctl options
 


### PR DESCRIPTION
Fix the broken hyperlink to start Stargate with an existing Cassandra cluster