### PR TITLE
Update UI bundle release to 0.5 for header/footer refresh

### DIFF
--- a/site-local.yaml
+++ b/site-local.yaml
@@ -11,7 +11,7 @@ content:
 
 ui:
   bundle:
-    url: https://github.com/stargate/antora-ui-stargate/releases/download/v0.4/ui-bundle.zip
+    url: https://github.com/stargate/antora-ui-stargate/releases/download/v0.5/ui-bundle.zip
   supplemental_files: ./supplemental-ui
   # override the default _ dir for assets, as Jekyll will delete them
   output_dir: assets

--- a/site-publish.yaml
+++ b/site-publish.yaml
@@ -11,7 +11,7 @@ content:
 
 ui:
   bundle:
-    url: https://github.com/stargate/antora-ui-stargate/releases/download/v0.4/ui-bundle.zip
+    url: https://github.com/stargate/antora-ui-stargate/releases/download/v0.5/ui-bundle.zip
   supplemental_files: ./supplemental-ui
   # override the default _ dir for assets, as Jekyll will delete them
   output_dir: assets


### PR DESCRIPTION
Last piece - update the site-local.yaml and site-publish.yaml to use the new v0.5 release of the ui bundle.