### PR TITLE
fixing more references to master branch

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -47,4 +47,4 @@ Go to our https://github.com/stargate/stargate/discussions[Github discussions pa
 //
 // == License
 //
-// This project uses the https://github.com/stargate/docs/blob/master/LICENSE[Apache 2.0 license].
+// This project uses the https://github.com/stargate/docs/blob/main/LICENSE[Apache 2.0 license].

--- a/modules/ROOT/pages/tooling.adoc
+++ b/modules/ROOT/pages/tooling.adoc
@@ -20,9 +20,9 @@ with Postman.
 
 For Stargate development, three collections that correspond to the documentation code examples are available:
 
-* link:https://github.com/stargate/docs/blob/master/modules/developers-guide/examples/json/Stargate-OSS-Astra-REST-API-users_keyspace.postman_collection.json[REST collection]
-* link:https://github.com/stargate/docs/blob/master/modules/developers-guide/examples/json/Stargate-OSS-Astra-Document-API-myworld.postman_collection.json[Document collection]
-* link:https://github.com/stargate/docs/blob/master/modules/developers-guide/examples/json/Stargate-OSS-Astra-GraphQL-API-library.postman_collection.json[GraphQL collection]
+* link:https://github.com/stargate/docs/blob/main/modules/developers-guide/examples/json/Stargate-OSS-Astra-REST-API-users_keyspace.postman_collection.json[REST collection]
+* link:https://github.com/stargate/docs/blob/main/modules/developers-guide/examples/json/Stargate-OSS-Astra-Document-API-myworld.postman_collection.json[Document collection]
+* link:https://github.com/stargate/docs/blob/main/modules/developers-guide/examples/json/Stargate-OSS-Astra-GraphQL-API-library.postman_collection.json[GraphQL collection]
 
 Each collection lets you try out creation, insertion, and deletion of both data and schema, as required.
 
@@ -31,8 +31,8 @@ Two environments are also available, one for the open-source Stargate docker ima
 A small amount of configuration is necessary in the single environment to set your
 parameters before use.
 
-* link:https://github.com/stargate/docs/blob/master/modules/developers-guide/examples/json/Stargate%20Astra%20API%20Environment.postman_environment.json[Astra environment]
-* link:https://github.com/stargate/docs/blob/master/modules/developers-guide/examples/json/Stargate%20OSS%20API%20Environment.postman_environment.json[Stargate OSS environment]
+* link:https://github.com/stargate/docs/blob/main/modules/developers-guide/examples/json/Stargate%20Astra%20API%20Environment.postman_environment.json[Astra environment]
+* link:https://github.com/stargate/docs/blob/main/modules/developers-guide/examples/json/Stargate%20OSS%20API%20Environment.postman_environment.json[Stargate OSS environment]
 
 === Postman environment configuration
 

--- a/modules/developers-guide/pages/graphql.adoc
+++ b/modules/developers-guide/pages/graphql.adoc
@@ -131,6 +131,6 @@ such as `createTable`, or `dropTable`.
 If you prefer, you can use Postman as a client interface for exploring the GraphQL API
 (https://www.postman.com/downloads/[download here, window="_blank"]).
 We've provided a
-https://raw.githubusercontent.com/stargate/docs/master/modules/developers-guide/examples/json/Stargate_GraphQL_API_library_Astra.postman_collection.json[Stargate GraphQL API Postman Astra Collection]
+https://raw.githubusercontent.com/stargate/docs/main/modules/developers-guide/examples/json/Stargate_GraphQL_API_library_Astra.postman_collection.json[Stargate GraphQL API Postman Astra Collection]
 that you can import in Postman to play with the examples shown in this walkthrough.
 // end::UsingPostman[]

--- a/modules/quickstart/pages/quick_start-rest.adoc
+++ b/modules/quickstart/pages/quick_start-rest.adoc
@@ -36,7 +36,7 @@ include::developers-guide:page$document-using.adoc[tag=UseAuthToken]
 If you prefer, you can use Postman as a client interface for exploring REST APIs
 (https://www.postman.com/downloads/[download here]).
 We've provided a
-https://github.com/stargate/docs/blob/master/modules/developers-guide/examples/json/Stargate_REST_v2_API_users_keyspace.postman_collection.json[Stargate REST API Postman Collection] that you can import in Postman to play with the examples shown in this walkthrough.
+https://github.com/stargate/docs/blob/main/modules/developers-guide/examples/json/Stargate_REST_v2_API_users_keyspace.postman_collection.json[Stargate REST API Postman Collection] that you can import in Postman to play with the examples shown in this walkthrough.
 
 Now you're ready to use the REST API for CRUD operations.
 // tag::endUsingPostman[]

--- a/site-local.yaml
+++ b/site-local.yaml
@@ -4,7 +4,7 @@ site:
   start_page: stargate::index.adoc
 
 content:
-  edit_url: 'https://github.com/stargate/docs/blob/master/{path}'
+  edit_url: 'https://github.com/stargate/docs/blob/main/{path}'
   sources:
     - url: .
       branches: HEAD

--- a/site-publish.yaml
+++ b/site-publish.yaml
@@ -4,7 +4,7 @@ site:
   start_page: stargate:quickstart:quickstart.adoc
 
 content:
-  edit_url: 'https://github.com/stargate/docs/blob/master/{path}'
+  edit_url: 'https://github.com/stargate/docs/blob/main/{path}'
   sources:
     - url: .
       branches: HEAD


### PR DESCRIPTION
found a few additional references to the old name `master` branch, mostly links within the site.