### PR TITLE
Add cache action to gh action workflows to increase speed

### DIFF
--- a/.github/workflows/antora.yml
+++ b/.github/workflows/antora.yml
@@ -45,11 +45,17 @@ jobs:
     name: "Deploy GitHub Pages"
     steps:
      - name: Setup Node.js for use with actions
-       uses: actions/setup-node@v1
+       uses: actions/setup-node@v2
        with:
          version: 14.x
      - name: Checkout
        uses: actions/checkout@v2
+     - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
      - name: Download generated site
        uses: actions/download-artifact@v2
        with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -46,11 +46,17 @@ jobs:
     name: "Deploy GitHub Pages"
     steps:
      - name: Setup Node.js for use with actions
-       uses: actions/setup-node@v1
+       uses: actions/setup-node@v2
        with:
          version: 14.x
      - name: Checkout
        uses: actions/checkout@v2
+     - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
      - name: Download generated site
        uses: actions/download-artifact@v2
        with:


### PR DESCRIPTION
https://www.voorhoede.nl/en/blog/super-fast-npm-install-on-github-actions/

I'm adding a gh action that I read about at the cited site. It seems a no-brainer to try it and see if it improves the processing time.