### PR TITLE
take out attachments link changes-no longer necessary

### DIFF
--- a/.github/workflows/antora.yml
+++ b/.github/workflows/antora.yml
@@ -48,12 +48,6 @@ jobs:
       - name: "List folder"
         run: |
           ls -ltra $GITHUB_WORKSPACE/build/$SITE_DIR/$SUB_DIR/develop
-      - name: "Fix attachments"
-        run: |
-          sudo mv $GITHUB_WORKSPACE/build/$SITE_DIR/$SUB_DIR/develop/_attachments $GITHUB_WORKSPACE/build/$SITE_DIR/$SUB_DIR/develop/attachments
-          sudo sed -i 's/_attachments/attachments/g' $GITHUB_WORKSPACE/build/$SITE_DIR/$SUB_DIR/develop/api.html
-          ls -ltra $GITHUB_WORKSPACE/build/$SITE_DIR
-          grep attachment $GITHUB_WORKSPACE/build/$SITE_DIR/$SUB_DIR/develop/api.html
       - name: "Copy index.html required for website"
         run: |
           sudo mv $GITHUB_WORKSPACE/index.html $GITHUB_WORKSPACE/build/$SITE_DIR

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,12 +45,6 @@ jobs:
       - name: "List folder"
         run: |
           ls -ltra $GITHUB_WORKSPACE/build/$SITE_DIR/$SUB_DIR/develop
-      - name: "Fix attachments"
-        run: |
-          sudo mv $GITHUB_WORKSPACE/build/$SITE_DIR/$SUB_DIR/develop/_attachments $GITHUB_WORKSPACE/build/$SITE_DIR/$SUB_DIR/develop/attachments
-          sudo sed -i 's/_attachments/attachments/g' $GITHUB_WORKSPACE/build/$SITE_DIR/$SUB_DIR/develop/api.html
-          ls -ltra $GITHUB_WORKSPACE/build/$SITE_DIR
-          grep attachment $GITHUB_WORKSPACE/build/$SITE_DIR/$SUB_DIR/develop/api.html
       - name: "Copy index.html required for website"
         run: |
           sudo mv $GITHUB_WORKSPACE/index.html $GITHUB_WORKSPACE/build/$SITE_DIR


### PR DESCRIPTION
Going to push this change - I used to do fancy stuff with the attachments links, but antora has implemented xrefs for attachments now.