### PR TITLE
Update docker compose instructions for v2

### DIFF
--- a/docs-src/stargate-core/modules/install/partials/docker_compose.adoc
+++ b/docs-src/stargate-core/modules/install/partials/docker_compose.adoc
@@ -26,10 +26,12 @@ You will want to run, for example:
 
 [source,bash,subs="attributes+"]
 ----
-./start_cass_{cass-alt-tag-3x}.sh -t {stargate2-docker-tag}
+./start_cass_{cass-alt-tag-3x}.sh
 ----
 
-The latest available image can be found https://hub.docker.com/r/stargateio/coordinator-3_11/tags[here].
+This command will start using the latest available coordinator and API images with the `v2` tag.
+
+You may also select a specific image tag using the `-t <image_tag>` option. A list of the available tags for the coordinator can be found https://hub.docker.com/r/stargateio/coordinator-3_11/tags[here].
 =====
 
 .v1
@@ -82,10 +84,12 @@ You will want to run, for example:
 
 [source,bash,subs="attributes+"]
 ----
-./start_cass_{cass-alt-tag-40}.sh -t {stargate2-docker-tag}
+./start_cass_{cass-alt-tag-40}.sh
 ----
 
-The latest available image can be found https://hub.docker.com/r/stargateio/coordinator-4_0/tags[here].
+This command will start using the latest available coordinator and API images with the `v2` tag.
+
+You may also select a specific image tag using the `-t <image_tag>` option. A list of the available tags for the coordinator can be found https://hub.docker.com/r/stargateio/coordinator-4_0/tags[here].
 =====
 
 .v1
@@ -137,10 +141,12 @@ You will want to run, for example:
 
 [source,bash,subs="attributes+"]
 ----
-./start_cass_{dse-alt-tag-68}.sh -t {stargate2-docker-tag}
+./start_cass_{dse-alt-tag-68}.sh
 ----
 
-The latest available image can be found https://hub.docker.com/r/stargateio/coordinator-dse-68/tags[here].
+This command will start using the latest available coordinator and API images with the `v2` tag.
+
+You may also select a specific image tag using the `-t <image_tag>` option. A list of the available tags for the coordinator can be found https://hub.docker.com/r/stargateio/coordinator-dse-68/tags[here].
 =====
 
 .v1

--- a/docs-src/stargate-core/modules/install/partials/docker_compose.adoc
+++ b/docs-src/stargate-core/modules/install/partials/docker_compose.adoc
@@ -21,7 +21,7 @@ delays between node startup that prevents timing issues.
 [%collapsible%open]
 ===== 
 Use this docker-compose https://github.com/stargate/stargate/blob/v2.0.0/docker-compose/cassandra-3.11/start_cass_311.sh[shell script] to start the coordinator and APIs in developer mode.
-The easiest way to do that is to navigate to the `<install_location>/stargate/stargate/docker-compose` directory, and run the script.
+The easiest way to do that is to navigate to the `<install_location>/stargate/docker-compose` directory, and run the script.
 You will want to run, for example:
 
 [source,bash,subs="attributes+"]
@@ -77,7 +77,7 @@ delays between node startup that prevents timing issues.
 [%collapsible%open]
 ===== 
 Use this docker-compose https://github.com/stargate/stargate/blob/v2.0.0/docker-compose/cassandra-4.0/start_cass_40.sh[shell script] to start the coordinator and APIs in developer mode.
-The easiest way to do that is to navigate to the `<install_location>/stargate/stargate/docker-compose` directory, and run the script.
+The easiest way to do that is to navigate to the `<install_location>/stargate/docker-compose` directory, and run the script.
 You will want to run, for example:
 
 [source,bash,subs="attributes+"]
@@ -132,7 +132,7 @@ delays between node startup that prevents timing issues.
 [%collapsible%open]
 ===== 
 Use this docker-compose https://github.com/stargate/stargate/blob/v2.0.0/docker-compose/dse-6.8/start_dse_68.sh[shell script] to start the coordinator and APIs in developer mode.
-The easiest way to do that is to navigate to the `<install_location>/stargate/stargate/docker-compose` directory, and run the script.
+The easiest way to do that is to navigate to the `<install_location>/stargate/docker-compose` directory, and run the script.
 You will want to run, for example:
 
 [source,bash,subs="attributes+"]

--- a/docs-src/stargate-core/modules/install/partials/docker_pull.adoc
+++ b/docs-src/stargate-core/modules/install/partials/docker_pull.adoc
@@ -16,8 +16,6 @@ docker pull stargateio/restapi:{stargate2-docker-tag}
 docker pull stargateio/docsapi:{stargate2-docker-tag}
 docker pull stargateio/graphqlapi:{stargate2-docker-tag}
 ----
-
-A list of the available tags for the coordinator can be found https://hub.docker.com/r/stargateio/coordinator-3_11/tags[here].
 =====
 
 .v1
@@ -49,8 +47,6 @@ docker pull stargateio/restapi:{stargate2-docker-tag}
 docker pull stargateio/docsapi:{stargate2-docker-tag}
 docker pull stargateio/graphqlapi:{stargate2-docker-tag}
 ----
-
-A list of the available tags for the coordinator can be found https://hub.docker.com/r/stargateio/coordinator-4_0/tags[here].
 =====
 
 .v1
@@ -82,8 +78,6 @@ docker pull stargateio/restapi:{stargate2-docker-tag}
 docker pull stargateio/docsapi:{stargate2-docker-tag}
 docker pull stargateio/graphqlapi:{stargate2-docker-tag}
 ----
-
-A list of the available tags for the coordinator can be found https://hub.docker.com/r/stargateio/coordinator-dse-68/tags[here].
 =====
 
 .v1

--- a/docs-src/stargate-core/modules/install/partials/docker_pull.adoc
+++ b/docs-src/stargate-core/modules/install/partials/docker_pull.adoc
@@ -7,7 +7,7 @@
 For Stargate v2, you'll need to pull an image for coordinator, plus an image for each API that you wish to run: restapi, graphql, and docsapi. 
 The coordinator image contains a Apache Cassandra^(TM)^ backend, the Cassandra Query Language (CQL), and the gRPC API.
 
-The following are the commands for each of those images:
+The following are the commands for each of those images using the tag `{stargate2-docker-tag}`:
 
 [source,bash,subs="attributes+"]
 ----
@@ -16,6 +16,8 @@ docker pull stargateio/restapi:{stargate2-docker-tag}
 docker pull stargateio/docsapi:{stargate2-docker-tag}
 docker pull stargateio/graphqlapi:{stargate2-docker-tag}
 ----
+
+A list of the available tags for the coordinator can be found https://hub.docker.com/r/stargateio/coordinator-3_11/tags[here].
 =====
 
 .v1
@@ -38,7 +40,7 @@ docker pull stargateio/stargate-{cass-alt-tag-3x}:{stargate-docker-tag-3x}
 For Stargate v2, you'll need to pull an image for coordinator, plus an image for each API that you wish to run: restapi, graphql, and docsapi. 
 The coordinator image contains a Apache Cassandra^(TM)^ backend, the Cassandra Query Language (CQL), and the gRPC API.
 
-The following are the commands for each of those images:
+The following are the commands for each of those images using the tag `{stargate2-docker-tag}`:
 
 [source,bash,subs="attributes+"]
 ----
@@ -47,6 +49,8 @@ docker pull stargateio/restapi:{stargate2-docker-tag}
 docker pull stargateio/docsapi:{stargate2-docker-tag}
 docker pull stargateio/graphqlapi:{stargate2-docker-tag}
 ----
+
+A list of the available tags for the coordinator can be found https://hub.docker.com/r/stargateio/coordinator-4_0/tags[here].
 =====
 
 .v1
@@ -69,7 +73,7 @@ docker pull stargateio/stargate-{cass-alt-tag-40}:{stargate-docker-tag-40}
 For Stargate v2, you'll need to pull an image for coordinator, plus an image for each API that you wish to run: restapi, graphql, and docsapi. 
 The coordinator image contains a Apache Cassandra^(TM)^ backend, the Cassandra Query Language (CQL), and the gRPC API.
 
-The following are the commands for each of those images:
+The following are the commands for each of those images using the tag `{stargate2-docker-tag}`:
 
 [source,bash,subs="attributes+"]
 ----
@@ -78,6 +82,8 @@ docker pull stargateio/restapi:{stargate2-docker-tag}
 docker pull stargateio/docsapi:{stargate2-docker-tag}
 docker pull stargateio/graphqlapi:{stargate2-docker-tag}
 ----
+
+A list of the available tags for the coordinator can be found https://hub.docker.com/r/stargateio/coordinator-dse-68/tags[here].
 =====
 
 .v1

--- a/docs-src/stargate-core/modules/install/partials/docker_run.adoc
+++ b/docs-src/stargate-core/modules/install/partials/docker_run.adoc
@@ -5,7 +5,7 @@
 [%collapsible%open]
 ===== 
 Use this docker-compose https://github.com/stargate/stargate/blob/v2.0.0/docker-compose/cassandra-3.11/start_cass_311_dev_mode.sh[shell script] to start the coordinator and APIs in developer mode.
-The easiest way to do that is to navigate to the `<install_location>/stargate/stargate/docker-compose` directory, and run the script.
+The easiest way to do that is to navigate to the `<install_location>/stargate/docker-compose` directory, and run the script.
 You will want to run, for example:
 
 [source,bash,subs="attributes+"]
@@ -44,7 +44,7 @@ docker run --name stargate \
 [%collapsible%open]
 ===== 
 Use this docker-compose https://github.com/stargate/stargate/blob/v2.0.0/docker-compose/cassandra-4.0/start_cass_40_dev_mode.sh[shell script] to start the coordinator and APIs in developer mode.
-The easiest way to do that is to navigate to the `<install_location>/stargate/stargate/docker-compose` directory, and run the script.
+The easiest way to do that is to navigate to the `<install_location>/stargate/docker-compose` directory, and run the script.
 You will want to run, for example:
 
 [source,bash,subs="attributes+"]
@@ -83,7 +83,7 @@ docker run --name stargate \
 [%collapsible%open]
 ===== 
 Use this docker-compose https://github.com/stargate/stargate/blob/v2.0.0/docker-compose/dse-6.8/start_cass_40_dev_mode.sh[shell script] to start the coordinator and APIs in developer mode.
-The easiest way to do that is to navigate to the `<install_location>/stargate/stargate/docker-compose` directory, and run the script.
+The easiest way to do that is to navigate to the `<install_location>/stargate/docker-compose` directory, and run the script.
 You will want to run, for example:
 
 [source,bash,subs="attributes+"]

--- a/docs-src/stargate-core/modules/install/partials/docker_run.adoc
+++ b/docs-src/stargate-core/modules/install/partials/docker_run.adoc
@@ -10,10 +10,12 @@ You will want to run, for example:
 
 [source,bash,subs="attributes+"]
 ----
-./start_cass_{cass-alt-tag-3x}_dev_mode.sh -t {stargate2-docker-tag}
+./start_cass_{cass-alt-tag-3x}_dev_mode.sh
 ----
 
-The latest available image can be found https://hub.docker.com/r/stargateio/coordinator-3_11/tags[here].
+This command will start using the latest available coordinator and API images with the `v2` tag.
+
+You may also select a specific image tag using the `-t <image_tag>` option. A list of the available tags for the coordinator can be found https://hub.docker.com/r/stargateio/coordinator-3_11/tags[here].
 =====
 
 .v1
@@ -49,10 +51,12 @@ You will want to run, for example:
 
 [source,bash,subs="attributes+"]
 ----
-./start_cass_{cass-alt-tag-40}_dev_mode.sh -t {stargate2-docker-tag}
+./start_cass_{cass-alt-tag-40}_dev_mode.sh
 ----
 
-The latest available image can be found https://hub.docker.com/r/stargateio/coordinator-4_0/tags[here].
+This command will start using the latest available coordinator and API images with the `v2` tag.
+
+You may also select a specific image tag using the `-t <image_tag>` option. A list of the available tags for the coordinator can be found https://hub.docker.com/r/stargateio/coordinator-4_0/tags[here].
 =====
 
 .v1
@@ -88,10 +92,12 @@ You will want to run, for example:
 
 [source,bash,subs="attributes+"]
 ----
-./start_dse_{dse-alt-tag-68}_dev_mode.sh -t {stargate2-docker-tag}
+./start_dse_{dse-alt-tag-68}_dev_mode.sh
 ----
 
-The latest available image can be found https://hub.docker.com/r/stargateio/coordinator-6.8/tags[here].
+This command will start using the latest available coordinator and API images with the `v2` tag.
+
+You may also select a specific image tag using the `-t <image_tag>` option. A list of the available tags for the coordinator can be found https://hub.docker.com/r/stargateio/coordinator-6.8/tags[here].
 =====
 
 .v1

--- a/playbooks/site-local-stargate.yaml
+++ b/playbooks/site-local-stargate.yaml
@@ -39,7 +39,7 @@ asciidoc:
     stargate-docker-tag-3x: v1.0.65
     stargate-docker-tag-40: v1.0.65
     stargate-docker-tag-68: v1.0.65
-    stargate2-docker-tag: v2.0.0-BETA-3
+    stargate2-docker-tag: v2
     cass-tag-3x: '3.11'
     cass-alt-tag-3x: '3_11'
     cass-tag-40: '4.0'

--- a/playbooks/site-publish-stargate-ghaction.yaml
+++ b/playbooks/site-publish-stargate-ghaction.yaml
@@ -40,7 +40,7 @@ asciidoc:
     stargate-docker-tag-3x: v1.0.57
     stargate-docker-tag-40: v1.0.57
     stargate-docker-tag-68: v1.0.57
-    stargate2-docker-tag: v2.0.0-BETA-3
+    stargate2-docker-tag: v2
     cass-tag-3x: '3.11'
     cass-alt-tag-3x: '3_11'
     cass-tag-40: '4.0'

--- a/playbooks/site-publish-stargate.yaml
+++ b/playbooks/site-publish-stargate.yaml
@@ -39,7 +39,7 @@ asciidoc:
     stargate-docker-tag-3x: v1.0.57
     stargate-docker-tag-40: v1.0.57
     stargate-docker-tag-68: v1.0.57
-    stargate2-docker-tag: v2.0.0-BETA-3
+    stargate2-docker-tag: v2
     cass-tag-3x: '3.11'
     cass-alt-tag-3x: '3_11'
     cass-tag-40: '4.0'


### PR DESCRIPTION
Updating docs to reflect usability improvements made to Stargate v2 docker-compose scripts under https://github.com/stargate/stargate/pull/2139, especially taking advantage of the default behavior which uses the `v2` tag and doesn't require use of the `-t` option.