### PR TITLE
encoding where clauses in REST API curl examples

### DIFF
--- a/docs-src/stargate-develop/modules/develop/examples/rest/curl_get_list_data.sh
+++ b/docs-src/stargate-develop/modules/develop/examples/rest/curl_get_list_data.sh
@@ -1,6 +1,6 @@
 curl -s -L -G {base_rest_url}{base_rest_schema}/{rkeyspace}/{rtable} \
-   -H  "X-Cassandra-Token: {auth_token}" \
-   -H  "Content-Type: application/json" \
+   -H "X-Cassandra-Token: {auth_token}" \
+   -H "Content-Type: application/json" \
    -H "Accept: application/json" \
    --data-urlencode 'where={
      "firstname": {"$eq": "Janesha"},

--- a/docs-src/stargate-develop/modules/develop/examples/rest/curl_get_map_data.sh
+++ b/docs-src/stargate-develop/modules/develop/examples/rest/curl_get_map_data.sh
@@ -1,7 +1,7 @@
 curl -s -L -G {base_rest_url}{base_rest_schema}/{rkeyspace}/{rtable} \
-   -H  "X-Cassandra-Token: {auth_token}" \
-   -H  "Content-Type: application/json" \
-    -H "Accept: application/json" \
+   -H "X-Cassandra-Token: {auth_token}" \
+   -H "Content-Type: application/json" \
+   -H "Accept: application/json" \
    --data-urlencode 'where={
      "firstname": {"$eq": "Janesha"},
      "lastname": {"$eq": "Doesha"},

--- a/docs-src/stargate-develop/modules/develop/examples/rest/curl_get_tuple_data.sh
+++ b/docs-src/stargate-develop/modules/develop/examples/rest/curl_get_tuple_data.sh
@@ -1,6 +1,7 @@
-curl -s -G -L {base_rest_url}{base_rest_schema}/{rkeyspace}/{rtable} \
-   -H  "X-Cassandra-Token: {auth_token}" \
-   -H  "Content-Type: application/json" \
+curl -s -L -G {base_rest_url}{base_rest_schema}/{rkeyspace}/{rtable} \
+   -H "X-Cassandra-Token: {auth_token}" \
+   -H "Content-Type: application/json" \
+   -H "Accept: application/json" \
    --data-urlencode 'where={
      "firstname": {"$eq": "Janesha"},
      "lastname": {"$eq": "Doesha"},

--- a/docs-src/stargate-develop/modules/develop/examples/rest/curl_get_udt_data.sh
+++ b/docs-src/stargate-develop/modules/develop/examples/rest/curl_get_udt_data.sh
@@ -5,5 +5,5 @@ curl -s -L -G {base_rest_url}{base_rest_schema}/{rkeyspace}/{rtable} \
    --data-urlencode 'where={
      "firstname": {"$eq": "Janesha"},
      "lastname": {"$eq": "Doesha"},
-     "address": {\"$eq\": { \"street\": \"1, Main St\", \"zip\": 12345 }}
+     "address": {"$eq": { "street": "1, Main St", "zip": 12345 }}
    }'

--- a/docs-src/stargate-develop/modules/develop/examples/rest/curl_get_users.sh
+++ b/docs-src/stargate-develop/modules/develop/examples/rest/curl_get_users.sh
@@ -1,3 +1,7 @@
-curl -s -L -X GET '{base_rest_url}{base_rest_api}/{rkeyspace}/{rtable}?where=\{"firstname":\{"$in":\["Janesha","Mookie"\]\}\}' \
--H "X-Cassandra-Token: {auth_token}" \
--H "Content-Type: application/json"
+curl -s -L -G '{base_rest_url}{base_rest_api}/{rkeyspace}/{rtable}' \
+   -H "X-Cassandra-Token: {auth_token}" \
+   -H "Content-Type: application/json" \
+   -H "Accept: application/json" \
+   --data-urlencode 'where={
+     "firstname": {"in": ["Janesha","Mookie"]}
+   }'

--- a/docs-src/stargate-develop/modules/develop/examples/rest/curl_get_users_mult_where.sh
+++ b/docs-src/stargate-develop/modules/develop/examples/rest/curl_get_users_mult_where.sh
@@ -1,3 +1,8 @@
-curl -s -L -X GET '{base_rest_url}{base_rest_api}/{rkeyspace}/{rtable}?where=\{"firstname":\{"$eq":"Janesha"\},"favorite_books":\{"$contains":"Emma"\}\}' \
---header "X-Cassandra-Token: {auth_token}" \
---header "Content-Type: application/json"
+curl -s -L -G '{base_rest_url}{base_rest_api}/{rkeyspace}/{rtable}' \
+   -H "X-Cassandra-Token: {auth_token}" \
+   -H "Content-Type: application/json" \
+   -H "Accept: application/json" \
+   --data-urlencode 'where={
+      "firstname": {"$eq": "Janesha"},
+      "favorite_books": {"$contains": "Emma"}
+   }'

--- a/docs-src/stargate-develop/modules/develop/examples/rest/curl_get_users_where.sh
+++ b/docs-src/stargate-develop/modules/develop/examples/rest/curl_get_users_where.sh
@@ -1,3 +1,7 @@
-curl -s -L -X GET '{base_rest_url}{base_rest_api}/{rkeyspace}/{rtable}?where=\{"firstname":\{"$eq":"Mookie"\}\}' \
---header "X-Cassandra-Token: {auth_token}" \
---header "Content-Type: application/json"
+curl -s -L -X GET '{base_rest_url}{base_rest_api}/{rkeyspace}/{rtable}' \
+   -H "X-Cassandra-Token: {auth_token}" \
+   -H "Content-Type: application/json" \
+   -H "Accept: application/json" \
+   --data-urlencode 'where={
+     "firstname": {"$eq": "Mookie"}
+   }'


### PR DESCRIPTION
updating curl samples to consistently use `--data-urlencode` option for `where` clauses