### PR TITLE
updating references to Git repo to reflect new branch names

### DIFF
--- a/docs-src/stargate-core/modules/concepts/pages/concepts.adoc
+++ b/docs-src/stargate-core/modules/concepts/pages/concepts.adoc
@@ -48,7 +48,7 @@ Stargate is broken up into modules that fit into three broad categories:
 
 The diagram below shows how these modules fit together.
 
-image::https://github.com/stargate/stargate/blob/master/assets/stargate-modules.png?raw=true[Stargate modules]
+image::https://github.com/stargate/stargate/blob/v1/assets/stargate-modules.png?raw=true[Stargate modules]
 
 API extensions are responsible for defining the API, handling and converting requests to database queries, dispatching requests to persistence services, and returning and serving response to clients.
 There are currently extensions for the Cassandra Query Language (CQL), and REST and GraphQL APIs for CRUD access to data in tables with many more coming soon.
@@ -57,7 +57,7 @@ These extensions use both the Authentication Extensions and the Persistence Exte
 The REST API uses the https://github.com/stargate/stargate/tree/master/auth-api[auth-api] to handle token access to the endpoints that are exposed by the Jetty-based Web Server. The GraphQL API also uses the token created with REST in
 the GrahpQL http header request to access the endpoints.
 The https://github.com/stargate/stargate/tree/master/persistence-api[persistence-api] is used to dispatch converted requests to the underlying storage engine.
-In the case of the REST API, you can see what this looks like in the https://github.com/stargate/stargate/blob/master/restapi/src/main/java/io/stargate/web/restapi/resources/v2/RowsResource.java[RowsResource].
+In the case of the REST API, you can see what this looks like in the https://github.com/stargate/stargate/blob/v1/restapi/src/main/java/io/stargate/web/restapi/resources/v2/RowsResource.java[RowsResource].
 
 Persistence extensions are responsible for implementing the coordination layer to execute requests passed by API services to underlying data storage instances.
 The Persistence extensions are currently Cassandra-centric as Cassandra is the first database we chose to implement.

--- a/docs-src/stargate-core/modules/install/pages/building.adoc
+++ b/docs-src/stargate-core/modules/install/pages/building.adoc
@@ -4,8 +4,8 @@
 This page covers the basics of building Stargate v1 or v2 from source. If you want further details, see
 the Developer Guide READMES:
 
-* https://github.com/stargate/stargate/blob/v2.0.0/DEV_GUIDE.md[v2 Developer Guide]
-* https://github.com/stargate/stargate/blob/master/DEV_GUIDE.md[v1 Developer Guide]
+* https://github.com/stargate/stargate/blob/main/DEV_GUIDE.md[v2 Developer Guide]
+* https://github.com/stargate/stargate/blob/v1/DEV_GUIDE.md[v1 Developer Guide]
 
 == Prerequisites
 

--- a/docs-src/stargate-develop/modules/develop/pages/api-grpc/gRPC-client-creation.adoc
+++ b/docs-src/stargate-develop/modules/develop/pages/api-grpc/gRPC-client-creation.adoc
@@ -31,10 +31,10 @@ The `batch` service executes a batch of CQL queries.
 
 === Proto files
 
-The https://github.com/stargate/stargate/blob/master/grpc-proto/proto/stargate.proto[`stargate.proto`]
+The https://github.com/stargate/stargate/blob/main/grpc-proto/proto/stargate.proto[`stargate.proto`]
 file provides these services that interact with a Stargate coordinator to execute
 CQL queries.
-The https://github.com/stargate/stargate/blob/master/grpc-proto/proto/query.proto[`query.proto`]
+The https://github.com/stargate/stargate/blob/main/grpc-proto/proto/query.proto[`query.proto`]
 file identifies the relevant messages required to interact with CQL.
 These include:
 

--- a/docs-src/stargate-develop/modules/develop/pages/api-grpc/java/java-processing.adoc
+++ b/docs-src/stargate-develop/modules/develop/pages/api-grpc/java/java-processing.adoc
@@ -14,4 +14,4 @@ include::example$java/java-grpc-processing.java[]
 Since the result type is known, the `getString` function transforms the value into a native string.
 Additional functions also exist for other types such as `int`, `map`, and `blob`.
 The full list can be found in
-link:https://github.com/stargate/stargate/blob/master/grpc-proto/src/main/java/io/stargate/grpc/Values.java[Values.java].
+link:https://github.com/stargate/stargate/blob/main/grpc-proto/src/main/java/io/stargate/grpc/Values.java[Values.java].


### PR DESCRIPTION
Fixes to docs that correspond with making `main` the new default branch on the `stargate/stargate` repo and renaming the legacy `master` branch to `v1`

This PR should not be merged until https://github.com/stargate/stargate/issues/1490 is closed.