### PR TITLE
fix broken links in quickstarts

### DIFF
--- a/docs-src/stargate-develop/modules/quickstart/pages/qs-document.adoc
+++ b/docs-src/stargate-develop/modules/quickstart/pages/qs-document.adoc
@@ -56,5 +56,5 @@ include::develop:page$api-doc/doc-document-deleting.adoc[Deleting documents and 
 
 Voila! For more information on the Document API, see the
 xref:develop:dev-with-doc.adoc[Using the Document API]
-or the https://stargate.io/docs/stargate/1.0/attachments/docv2.html[Document API] in the
+or the https://stargate.io/docs/latest/develop/attachments/docv2.html[Document API] in the
 API references section.

--- a/docs-src/stargate-develop/modules/quickstart/pages/qs-rest.adoc
+++ b/docs-src/stargate-develop/modules/quickstart/pages/qs-rest.adoc
@@ -50,5 +50,5 @@ include::develop:page$api-rest/rest-deleting-rows.adoc[Deleting rows in your tab
 
 Voila! For more information on the REST API, see the see the
 xref:develop:dev-with-rest.adoc[Using the REST API]
-or the https://stargate.io/docs/stargate/1.0/attachments/restv2.html[REST API] in the
+or the https://stargate.io/docs/latest/develop/attachments/restv2.html[REST API] in the
 API references section.


### PR DESCRIPTION
[Daniel Santos] in slack
Hey folks, I think this broken link should be replaced with a more stable version such as
[https://stargate.io/docs/latest/develop/attachments/restv2.html]https://stargate.io/docs/latest/develop/attachments/restv2.html