### PR TITLE
DOC-3969: revert back to links for APIs and add back in attachments move step in GH action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,13 @@ jobs:
       - name: Setup gradle
         uses: gradle/gradle-build-action@v2
       - name: Execute gradle build to run antora
-        run: ./gradlew antora      
+        run: ./gradlew antora  
+      - name: "Fix attachments"
+        run: |
+          sudo mv $GITHUB_WORKSPACE/build/$SITE_DIR/$SUB_DIR/develop/_attachments $GITHUB_WORKSPACE/build/$SITE_DIR/$SUB_DIR/develop/attachments
+          sudo sed -i 's/_attachments/attachments/g' $GITHUB_WORKSPACE/build/$SITE_DIR/$SUB_DIR/develop/api.html
+          ls -ltra $GITHUB_WORKSPACE/build/$SITE_DIR
+          grep attachment $GITHUB_WORKSPACE/build/$SITE_DIR/$SUB_DIR/develop/api.html    
       - name: Upload generated site
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,12 @@ jobs:
         uses: gradle/gradle-build-action@v2
       - name: Execute gradle build to run antora
         run: ./gradlew antora   
+      - name: "Fix attachments"
+        run: |
+          sudo mv $GITHUB_WORKSPACE/build/$SITE_DIR/$SUB_DIR/develop/_attachments $GITHUB_WORKSPACE/build/$SITE_DIR/$SUB_DIR/develop/attachments
+          sudo sed -i 's/_attachments/attachments/g' $GITHUB_WORKSPACE/build/$SITE_DIR/$SUB_DIR/develop/api.html
+          ls -ltra $GITHUB_WORKSPACE/build/$SITE_DIR
+          grep attachment $GITHUB_WORKSPACE/build/$SITE_DIR/$SUB_DIR/develop/api.html    
       - name: "Copy index.html required for website"
         run: |
           sudo mv $GITHUB_WORKSPACE/index.html $GITHUB_WORKSPACE/build/$SITE_DIR

--- a/docs-src/stargate-develop/modules/develop/pages/api.adoc
+++ b/docs-src/stargate-develop/modules/develop/pages/api.adoc
@@ -4,9 +4,9 @@ Stargate provides multiple APIs to interact with your databases.
 
 == Stargate APIs
 
-* xref:develop:attachment$docv2.html[{database} Document API v2, window="_blank"]: The Stargate Document API allows you to use schemaless storage of free-form JSON Documents in your {astra_db} database. Get examples of using the Document API in the xref:develop:dev-with-doc.adoc[Developing with the Document API] section.
+* http://stargate.io/docs/latest/develop/attachments/docv2.html[{database} Document API v2, window="_blank"]: The Stargate Document API allows you to use schemaless storage of free-form JSON Documents in your {astra_db} database. Get examples of using the Document API in the xref:develop:dev-with-doc.adoc[Developing with the Document API] section.
 
-* xref:develop:attachment$restv2.html[{database} REST API v2, window="_blank"]: The Stargate REST API allows you to perform standard CRUD operations on your {astra_db} data using a simple, cross-language interface. Get examples of using the REST API v2 in the xref:develop:dev-with-rest.adoc[Developing with the REST API] section.
+* http://stargate.io/docs/latest/develop/attachments/restv2.html[{database} REST API v2, window="_blank"]: The Stargate REST API allows you to perform standard CRUD operations on your {astra_db} data using a simple, cross-language interface. Get examples of using the REST API v2 in the xref:develop:dev-with-rest.adoc[Developing with the REST API] section.
 
 * xref:graphql.adoc[Stargate GraphQL API, window="_blank"]: The GraphQL playground allows you to easily interact with your data using GraphQL types, queries, and mutations. For every table in your keyspace, a series of GraphQL objects are generated, along with queries and mutations that allow you to search and modify the table data. Get examples of using the GraphQL API in the xref:develop:graphql.adoc[Developing with the GraphQL API] section.
 
@@ -14,5 +14,5 @@ Stargate provides multiple APIs to interact with your databases.
 
 === Prior Stargate version
 
-* xref:develop:attachment$restv1.html[Stargate REST API v1, window="_blank"]
+* http://stargate.io/docs/latest/develop/attachments/restv1.html[Stargate REST API v1, window="_blank"]
 


### PR DESCRIPTION
Per the work John, Eric, and I did on Friday, reverting some changes in api linking until we can fix "the jekyll problem".