### PR TITLE
Correct pull coordinate for DSE coordinator container

### DIFF
--- a/docs-src/stargate-core/modules/install/partials/docker_pull.adoc
+++ b/docs-src/stargate-core/modules/install/partials/docker_pull.adoc
@@ -73,7 +73,7 @@ The following are the commands for each of those images using the tag `{stargate
 
 [source,bash,subs="attributes+"]
 ----
-docker pull stargateio/coordinator-{dse-alt-tag-68}:{stargate2-docker-tag}
+docker pull stargateio/coordinator-dse-{dse-alt-tag-68}:{stargate2-docker-tag}
 docker pull stargateio/restapi:{stargate2-docker-tag}
 docker pull stargateio/docsapi:{stargate2-docker-tag}
 docker pull stargateio/graphqlapi:{stargate2-docker-tag}

--- a/docs-src/stargate-core/modules/install/partials/docker_run.adoc
+++ b/docs-src/stargate-core/modules/install/partials/docker_run.adoc
@@ -97,7 +97,7 @@ You will want to run, for example:
 
 This command will start using the latest available coordinator and API images with the `v2` tag.
 
-You may also select a specific image tag using the `-t <image_tag>` option. A list of the available tags for the coordinator can be found https://hub.docker.com/r/stargateio/coordinator-6.8/tags[here].
+You may also select a specific image tag using the `-t <image_tag>` option. A list of the available tags for the coordinator can be found https://hub.docker.com/r/stargateio/coordinator-dse-68/tags[here].
 =====
 
 .v1


### PR DESCRIPTION
The Docker repo listed in the docs does not match the repo name in Docker Hub.

https://hub.docker.com/r/stargateio/coordinator-dse-68 exists
https://hub.docker.com/r/stargateio/coordinator-68 does not

This change corrects the documentation.