### PR TITLE
Replace deprecated gradle build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           fi          
           ln -s antora-stargate.yml antora.yml
       - name: Setup gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v4
       - name: Execute gradle build to run antora
         run: ./gradlew antora  
       - name: "Fix attachments"


### PR DESCRIPTION
Per the deprecation [notice](https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle) we are replacing it now to avoid the following errors as seen [here](https://github.com/stargate/docs/actions/runs/10621358095#summary-29443127308).